### PR TITLE
feat: Allow recursive processing of config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ In standard FluxCD setups, postBuild substitutions in Kustomizations can only re
 
 ## How It Works
 
-The webhook listens for Kustomization resources creation or update events. On intercepting such an event, it dynamically injects substitution variables into the Kustomization resource. These variables are fetched from a centralized ConfigMap, allowing for consistent and centralized management of configurations used across various namespaces.
+The webhook listens for Kustomization resources creation or update events. On intercepting such an event, it dynamically injects substitution variables into the Kustomization resource. These variables are fetched from centralized ConfigMaps or Secrets, allowing for consistent and centralized management of configurations used across various namespaces.
 
 ## Prerequisites
 
-The Kustomize Mutating Webhook is pre-configured to mount the configmap called `cluster-config` however, this can be set to any name. Ensure this exists in the cluster otherwise there will be no values to patch into your FluxCD Kustomization resources. Also see [Changing ConfigMap Reference](#changing-configmap-reference)
+The Kustomize Mutating Webhook is pre-configured to mount a configMap named `cluster-config`. This can be configured to any name. Ensure this exists in the cluster otherwise there will be no values to patch into your FluxCD Kustomization resources. Also see [Changing ConfigMap / Secret Reference](#changing-configmap--secret-reference)
 
 Additionally, the following are required:
 
@@ -80,9 +80,9 @@ Check the logs of the webhook to ensure that the log level has changed:
 kubectl logs --selector=app=kustomize-mutating-webhook -n flux-system
 ```
 
-### Changing ConfigMap Reference
+### Changing ConfigMap / Secret Reference
 
-The webhook is designed to fetch substitution variables from a specified ConfigMap. To change the ConfigMap it references:
+The webhook is designed to fetch substitution variables from specified ConfigMaps and / or Secrets as long as they are mounted into the configuration directory (which defaults to `/etc/config`) or any of its subdirectories.
 
 1. Update the ConfigMap Kubernetes Deployment
 

--- a/kubernetes/chart/Chart.yaml
+++ b/kubernetes/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kustomize-mutating-webhook
 description: A Helm chart for FluxCD Kustomize Mutating Webhook
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.0.0"

--- a/kubernetes/chart/templates/configmap.yaml
+++ b/kubernetes/chart/templates/configmap.yaml
@@ -1,11 +1,13 @@
-{{- if .Values.configMap.create -}}
+{{- range $configMap := .Values.configMaps }}
+{{- if $configMap.create -}}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.configMap.name }}
+  name: {{ $configMap.name }}
   labels:
     {{- include "kustomize-mutating-webhook.labels" . | nindent 4 }}
 data:
-  {{- toYaml .Values.configMap.data | nindent 2 }}
+  {{- toYaml $configMap.data | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/kubernetes/chart/templates/deployment.yaml
+++ b/kubernetes/chart/templates/deployment.yaml
@@ -58,16 +58,30 @@ spec:
             - name: webhook-certs
               mountPath: /etc/webhook/certs
               readOnly: true
-            - name: cluster-config
-              mountPath: /etc/config
+            {{- range $configMap := .Values.configMaps }}
+            - name: {{ $configMap.name }}
+              mountPath: /etc/config/{{ regexReplaceAll "\\W+" $configMap.name "_" }}
               readOnly: true
+            {{- end }}
+            {{- range $secret := .Values.secrets }}
+            - name: {{ $secret.name }}
+              mountPath: /etc/config/{{ regexReplaceAll "\\W+" $secret.name "_" }}
+              readOnly: true
+            {{- end }}
       volumes:
         - name: webhook-certs
           secret:
             secretName: {{ include "kustomize-mutating-webhook.fullname" . }}-tls
-        - name: cluster-config
+        {{- range $configMap := .Values.configMaps }}
+        - name: {{ $configMap.name }}
           configMap:
-            name: {{ .Values.configMap.name }}
+            name: {{ $configMap.name }}
+        {{- end }}
+        {{- range $secret := .Values.secrets }}
+        - name: {{ $secret.name }}
+          configMap:
+            name: {{ $secret.name }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/kubernetes/chart/values.yaml
+++ b/kubernetes/chart/values.yaml
@@ -62,10 +62,12 @@ certManager:
   certificateDuration: "1h"
   certificateRenewBefore: "30m"
 
-configMap:
-  create: false
-  name: cluster-config
-  data: {}
+configMaps:
+  - create: false
+    name: cluster-config
+    data: {}
+
+secrets: []
 
 env:
   LOG_LEVEL: info


### PR DESCRIPTION
This PR makes it so that the webhook traverses the configuration directory recursively.
That makes it possible to mount multiple configMaps and/or Secrets into the folder and have them be processed by the webhook.

I (think)I have made most of the Helm chart changes backwards compatible, but since it's version < 1.0 _technically_ we aren't breaking semVer anyway ;)