### PR TITLE
make certificate issuer configurable

### DIFF
--- a/deploy/chart/fluxcd-mutating-webhook/Chart.yaml
+++ b/deploy/chart/fluxcd-mutating-webhook/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kustomize-mutating-webhook
 description: A Helm chart for FluxCD Kustomize Mutating Webhook
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "1.0.0"

--- a/deploy/chart/fluxcd-mutating-webhook/templates/deployment.yaml
+++ b/deploy/chart/fluxcd-mutating-webhook/templates/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "kustomize-mutating-webhook.fullname" . }}
   labels:
     {{- include "kustomize-mutating-webhook.labels" . | nindent 4 }}
+    {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -23,6 +26,9 @@ spec:
     metadata:
       labels:
         {{- include "kustomize-mutating-webhook.selectorLabels" . | nindent 8 }}
+        {{- with .Values.additionalLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/deploy/chart/fluxcd-mutating-webhook/templates/pki.yaml
+++ b/deploy/chart/fluxcd-mutating-webhook/templates/pki.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.certManager.enabled -}}
-{{- if not .Values.certManager.GoogleCASClusterIssuerCertificate.enabled -}}
+{{- if not .Values.certManager.CASClusterIssuer.enabled -}}
 ---
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
@@ -50,11 +50,11 @@ spec:
   dnsNames:
     - {{ include "kustomize-mutating-webhook.fullname" . }}.{{ .Release.Namespace }}.svc
     - {{ include "kustomize-mutating-webhook.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
-  {{- if .Values.certManager.GoogleCASClusterIssuerCertificate.enabled }}
+  {{- if .Values.certManager.CASClusterIssuer.enabled }}
   issuerRef:
-    group: cas-issuer.jetstack.io
-    kind: GoogleCASClusterIssuer
-    name: {{ .Values.certManager.GoogleCASClusterIssuerCertificate.name }}
+    group: {{ .Values.certManager.CASClusterIssuer.group }}
+    kind: {{ .Values.certManager.CASClusterIssuer.kind }}
+    name: {{ .Values.certManager.CASClusterIssuer.name }}
   {{- else }}
   issuerRef:
     name: {{ include "kustomize-mutating-webhook.fullname" . }}

--- a/deploy/chart/fluxcd-mutating-webhook/templates/pki.yaml
+++ b/deploy/chart/fluxcd-mutating-webhook/templates/pki.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.certManager.enabled -}}
+{{- if not .Values.certManager.GoogleCASClusterIssuerCertificate.enabled -}}
 ---
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
@@ -37,6 +38,7 @@ metadata:
 spec:
   ca:
     secretName: {{ include "kustomize-mutating-webhook.fullname" . }}-ca
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -48,9 +50,16 @@ spec:
   dnsNames:
     - {{ include "kustomize-mutating-webhook.fullname" . }}.{{ .Release.Namespace }}.svc
     - {{ include "kustomize-mutating-webhook.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  {{- if .Values.certManager.GoogleCASClusterIssuerCertificate.enabled }}
+  issuerRef:
+    group: cas-issuer.jetstack.io
+    kind: GoogleCASClusterIssuer
+    name: {{ .Values.certManager.GoogleCASClusterIssuerCertificate.name }}
+  {{- else }}
   issuerRef:
     name: {{ include "kustomize-mutating-webhook.fullname" . }}
     kind: Issuer
+  {{- end }}
   secretName: {{ include "kustomize-mutating-webhook.fullname" . }}-tls
   duration: {{ .Values.certManager.certificateDuration | default "2160h" }}
   renewBefore: {{ .Values.certManager.certificateRenewBefore | default "360h" }}

--- a/deploy/chart/fluxcd-mutating-webhook/values.yaml
+++ b/deploy/chart/fluxcd-mutating-webhook/values.yaml
@@ -59,6 +59,9 @@ certManager:
   enabled: true
   certificateDuration: "2160h" # 90d
   certificateRenewBefore: "360h" # 15d
+  GoogleCASClusterIssuerCertificate:
+    enabled: false
+    name: googlecasissuer-cas
 
 configMaps:
   - create: false

--- a/deploy/chart/fluxcd-mutating-webhook/values.yaml
+++ b/deploy/chart/fluxcd-mutating-webhook/values.yaml
@@ -60,7 +60,7 @@ certManager:
   certificateDuration: "2160h" # 90d
   certificateRenewBefore: "360h" # 15d
   CASClusterIssuer:
-    enabled: true
+    enabled: false
     group: "awspca.cert-manager.io" # cas-issuer.jetstack.io|awspca.cert-manager.io
     kind: "AWSPCAClusterIssuer" # GoogleCASClusterIssuer|AWSPCAClusterIssuer
     name: casissuer-name

--- a/deploy/chart/fluxcd-mutating-webhook/values.yaml
+++ b/deploy/chart/fluxcd-mutating-webhook/values.yaml
@@ -59,9 +59,11 @@ certManager:
   enabled: true
   certificateDuration: "2160h" # 90d
   certificateRenewBefore: "360h" # 15d
-  GoogleCASClusterIssuerCertificate:
-    enabled: false
-    name: googlecasissuer-cas
+  CASClusterIssuer:
+    enabled: true
+    group: "awspca.cert-manager.io" # cas-issuer.jetstack.io|awspca.cert-manager.io
+    kind: "AWSPCAClusterIssuer" # GoogleCASClusterIssuer|AWSPCAClusterIssuer
+    name: casissuer-name
 
 configMaps:
   - create: false

--- a/deploy/chart/fluxcd-mutating-webhook/values.yaml
+++ b/deploy/chart/fluxcd-mutating-webhook/values.yaml
@@ -38,6 +38,8 @@ resources:
     cpu: 500m
     memory: 256Mi
 
+additionalLabels: {}
+  # custom-label: "example"
 annotations: {}
 podAnnotations: {}
 


### PR DESCRIPTION
- make certificate issuer configurable.
- add additional deployment and pod labels 

You can now specify a Certificate Authority that belongs to a cloud provider:

```
# AWS CAS issuer example
certManager:
  enabled: true
  CASClusterIssuer:
    enabled: true
    group: "awspca.cert-manager.io"
    kind: "AWSPCAClusterIssuer"
    name: AWS-casissuer-name

# GCP CAS issuer example
certManager:
  enabled: true
  CASClusterIssuer:
    enabled: true
    group: "cas-issuer.jetstack.io"
    kind: "GoogleCASClusterIssuer"
    name: Google-casissuer-name
```