### PR TITLE
Fix Chart appVersion to 0.10.0 and auto-sync on future releases

### DIFF
--- a/deploy/chart/kustomize-mutating-webhook/Chart.yaml
+++ b/deploy/chart/kustomize-mutating-webhook/Chart.yaml
@@ -3,5 +3,5 @@ name: kustomize-mutating-webhook
 description: A Helm chart for the Kustomize Mutating Webhook chart
 type: application
 version: 0.10.0
-appVersion: "0.5.0"
+appVersion: "0.10.0"
 kubeVersion: ">=1.19.0-0"

--- a/deploy/chart/kustomize-mutating-webhook/README.md
+++ b/deploy/chart/kustomize-mutating-webhook/README.md
@@ -1,6 +1,6 @@
 # kustomize-mutating-webhook
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
 
 A Helm chart for the Kustomize Mutating Webhook chart
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,13 @@
     "kustomize-mutating-webhook": {
       "package-name": "kustomize-mutating-webhook",
       "release-type": "go",
+      "extra-files": [
+        {
+          "type": "yaml",
+          "path": "../deploy/chart/kustomize-mutating-webhook/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        }
+      ],
       "changelog-sections": [
         {
           "type": "feat",


### PR DESCRIPTION
## Summary

- Set `appVersion` in `Chart.yaml` to `0.10.0` (was stuck at `0.5.0`)
- Add `extra-files` config to release-please so future app version bumps automatically update `appVersion`

## Why

The chart's `appVersion` determines the default image tag (`{{ .Chart.AppVersion }}`). It was `0.5.0` while the actual app and chart are both `0.10.0`, causing default installs to pull a stale image.

## How it works going forward

When release-please bumps the Go app version in `.release-please-manifest.json`, the `extra-files` config tells it to also update `Chart.yaml`'s `appVersion` field via YAML jsonpath.