### PR TITLE
Validate config keys against Flux substitute regex

### DIFF
--- a/kustomize-mutating-webhook/pkg/utils/configwatcher.go
+++ b/kustomize-mutating-webhook/pkg/utils/configwatcher.go
@@ -163,6 +163,7 @@ func (ci *ConfigInformer) reloadConfig() {
 	}
 	sort.Strings(cmNames)
 
+	var invalidKeys []string
 	for _, name := range cmNames {
 		cm, err := ci.cmLister.Get(name)
 		if err != nil {
@@ -170,6 +171,11 @@ func (ci *ConfigInformer) reloadConfig() {
 			continue
 		}
 		for k, v := range cm.Data {
+			if !IsValidSubstituteKey(k) {
+				invalidKeys = append(invalidKeys, k)
+				log.Warn().Str("key", k).Str("configmap", name).Msg("Skipping invalid substitute key (must match ^[_a-zA-Z][_a-zA-Z0-9]*$)")
+				continue
+			}
 			config[k] = v
 		}
 	}
@@ -188,8 +194,20 @@ func (ci *ConfigInformer) reloadConfig() {
 			continue
 		}
 		for k, v := range s.Data {
+			if !IsValidSubstituteKey(k) {
+				invalidKeys = append(invalidKeys, k)
+				log.Warn().Str("key", k).Str("secret", name).Msg("Skipping invalid substitute key (must match ^[_a-zA-Z][_a-zA-Z0-9]*$)")
+				continue
+			}
 			config[k] = string(v)
 		}
+	}
+
+	if len(invalidKeys) > 0 {
+		log.Warn().
+			Int("count", len(invalidKeys)).
+			Strs("keys", invalidKeys).
+			Msg("Invalid substitute keys skipped (Flux requires ^[_a-zA-Z][_a-zA-Z0-9]*$)")
 	}
 
 	if len(config) == 0 && oldCount > 0 {

--- a/kustomize-mutating-webhook/pkg/utils/configwatcher_test.go
+++ b/kustomize-mutating-webhook/pkg/utils/configwatcher_test.go
@@ -153,15 +153,15 @@ func TestConfigInformer_MultipleResources(t *testing.T) {
 
 	cm1 := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "config1", Namespace: "test-ns"},
-		Data:       map[string]string{"cm-key1": "cm-val1"},
+		Data:       map[string]string{"CM_KEY1": "cm-val1"},
 	}
 	cm2 := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "config2", Namespace: "test-ns"},
-		Data:       map[string]string{"cm-key2": "cm-val2"},
+		Data:       map[string]string{"CM_KEY2": "cm-val2"},
 	}
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: "test-ns"},
-		Data:       map[string][]byte{"sec-key1": []byte("sec-val1")},
+		Data:       map[string][]byte{"SEC_KEY1": []byte("sec-val1")},
 	}
 	clientset := fake.NewSimpleClientset(cm1, cm2, s)
 
@@ -178,9 +178,9 @@ func TestConfigInformer_MultipleResources(t *testing.T) {
 	}, 5*time.Second, 50*time.Millisecond)
 
 	AppConfig.Mu.RLock()
-	assert.Equal(t, "cm-val1", AppConfig.Config["cm-key1"])
-	assert.Equal(t, "cm-val2", AppConfig.Config["cm-key2"])
-	assert.Equal(t, "sec-val1", AppConfig.Config["sec-key1"])
+	assert.Equal(t, "cm-val1", AppConfig.Config["CM_KEY1"])
+	assert.Equal(t, "cm-val2", AppConfig.Config["CM_KEY2"])
+	assert.Equal(t, "sec-val1", AppConfig.Config["SEC_KEY1"])
 	AppConfig.Mu.RUnlock()
 }
 
@@ -380,4 +380,43 @@ func TestConfigInformer_AutoUpdateTrigger(t *testing.T) {
 		}
 		return false
 	}, 5*time.Second, 50*time.Millisecond, "auto-update should patch kustomizations after config change")
+}
+
+func TestConfigInformer_InvalidKeysSkipped(t *testing.T) {
+	resetAppConfig()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-config", Namespace: "test-ns"},
+		Data: map[string]string{
+			"VALID_KEY":    "good",
+			"ALSO_VALID":   "good",
+			"INVALID-KEY":  "bad-hyphen",
+			"123_BAD":      "bad-starts-with-digit",
+			"has space":    "bad-space",
+		},
+	}
+	clientset := fake.NewSimpleClientset(cm)
+
+	ci := NewConfigInformer(clientset, "test-ns", []string{"test-config"}, nil, false, nil)
+
+	go ci.Start()
+	defer ci.Stop()
+
+	require.Eventually(t, func() bool {
+		AppConfig.Mu.RLock()
+		defer AppConfig.Mu.RUnlock()
+		return len(AppConfig.Config) == 2
+	}, 5*time.Second, 50*time.Millisecond)
+
+	AppConfig.Mu.RLock()
+	assert.Equal(t, "good", AppConfig.Config["VALID_KEY"])
+	assert.Equal(t, "good", AppConfig.Config["ALSO_VALID"])
+	_, hasInvalid := AppConfig.Config["INVALID-KEY"]
+	_, hasDigit := AppConfig.Config["123_BAD"]
+	_, hasSpace := AppConfig.Config["has space"]
+	AppConfig.Mu.RUnlock()
+
+	assert.False(t, hasInvalid, "hyphenated key should be skipped")
+	assert.False(t, hasDigit, "digit-starting key should be skipped")
+	assert.False(t, hasSpace, "space key should be skipped")
 }

--- a/kustomize-mutating-webhook/pkg/utils/utils.go
+++ b/kustomize-mutating-webhook/pkg/utils/utils.go
@@ -1,13 +1,24 @@
 package utils
 
 import (
+	"regexp"
 	"strings"
 	"sync"
 )
 
+// varsubRegex matches the Flux kustomize-controller variable substitution pattern.
+// Keys must start with a letter or underscore, followed by letters, digits, or underscores.
+// Source: https://github.com/fluxcd/pkg/blob/main/kustomize/kustomize_varsub.go
+var varsubRegex = regexp.MustCompile(`^[_a-zA-Z][_a-zA-Z0-9]*$`)
+
 var AppConfig struct {
 	Mu     sync.RWMutex
 	Config map[string]string
+}
+
+// IsValidSubstituteKey checks whether a key is a valid Flux postBuild substitute variable name.
+func IsValidSubstituteKey(key string) bool {
+	return varsubRegex.MatchString(key)
 }
 
 func EscapeJsonPointer(value string) string {

--- a/kustomize-mutating-webhook/pkg/utils/utils_test.go
+++ b/kustomize-mutating-webhook/pkg/utils/utils_test.go
@@ -6,6 +6,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestIsValidSubstituteKey(t *testing.T) {
+	tests := []struct {
+		key   string
+		valid bool
+	}{
+		{"CLUSTER_NAME", true},
+		{"_PRIVATE", true},
+		{"a", true},
+		{"A1B2C3", true},
+		{"_", true},
+		{"__double__", true},
+		{"CLUSTER-NAME", false},   // hyphen not allowed
+		{"cluster.name", false},   // dot not allowed
+		{"123_START", false},      // starts with digit
+		{"", false},               // empty
+		{"HAS SPACE", false},      // space not allowed
+		{"key/slash", false},      // slash not allowed
+		{"key=value", false},      // equals not allowed
+		{"café", false},           // non-ASCII not allowed
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			assert.Equal(t, tt.valid, IsValidSubstituteKey(tt.key), "key: %q", tt.key)
+		})
+	}
+}
+
 func TestEscapeJsonPointer(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Validates ConfigMap and Secret keys against the Flux kustomize-controller variable substitution regex before injecting them into Kustomizations.

Closes #13

## What it does

Keys that don't match `^[_a-zA-Z][_a-zA-Z0-9]*$` (the same regex Flux uses internally) are skipped during config loading with a warning log. This prevents silent failures where the webhook injects a variable that Flux later rejects at substitution time.

Examples of invalid keys that are now caught:
- `CLUSTER-NAME` (hyphen)
- `cluster.domain` (dot)
- `123_START` (starts with digit)

## Changes

- `pkg/utils/utils.go` — Added `IsValidSubstituteKey()` using Flux's regex
- `pkg/utils/configwatcher.go` — Validate keys in `reloadConfig()`, skip invalid ones with warning
- `pkg/utils/utils_test.go` — Table-driven tests for key validation
- `pkg/utils/configwatcher_test.go` — Integration test verifying invalid keys are skipped; updated existing test data to use valid key names

## Test plan

- [x] `go test -race ./...` — all pass
- [x] Invalid keys logged with warning including the key name and source (ConfigMap/Secret name)
- [x] Valid keys unaffected