### PR TITLE
Fix readiness probe to not require config keys

### DIFF
--- a/kustomize-mutating-webhook/cmd/webhook/main.go
+++ b/kustomize-mutating-webhook/cmd/webhook/main.go
@@ -71,6 +71,9 @@ func main() {
 		kustomizationUpdater,
 	)
 
+	// Wire readiness check to informer cache sync status
+	webhook.ReadinessCheck = configInformer.Ready
+
 	server, err := webhook.NewServer(cfg)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create server")

--- a/kustomize-mutating-webhook/internal/webhook/server.go
+++ b/kustomize-mutating-webhook/internal/webhook/server.go
@@ -14,9 +14,13 @@ import (
 	"github.com/xunholy/fluxcd-mutating-webhook/internal/config"
 	"github.com/xunholy/fluxcd-mutating-webhook/internal/handlers"
 	"github.com/xunholy/fluxcd-mutating-webhook/internal/metrics"
-	"github.com/xunholy/fluxcd-mutating-webhook/pkg/utils"
 	"golang.org/x/time/rate"
 )
+
+// ReadinessCheck is called by the /ready endpoint to determine if the webhook is ready.
+// It should be set by main.go to the ConfigInformer's Ready() method.
+// Defaults to always-ready if not set.
+var ReadinessCheck func() bool
 
 type Server struct {
 	*http.Server
@@ -93,25 +97,21 @@ func handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleReady(w http.ResponseWriter, r *http.Request) {
-	utils.AppConfig.Mu.RLock()
-	configLoaded := len(utils.AppConfig.Config) > 0
-	utils.AppConfig.Mu.RUnlock()
+	isReady := ReadinessCheck == nil || ReadinessCheck()
 
 	status := "Ready"
 	statusCode := http.StatusOK
-	if !configLoaded {
+	if !isReady {
 		status = "NotReady"
 		statusCode = http.StatusServiceUnavailable
 	}
 
 	ready := struct {
-		Status       string `json:"status"`
-		ConfigLoaded bool   `json:"configLoaded"`
-		Timestamp    string `json:"timestamp"`
+		Status    string `json:"status"`
+		Timestamp string `json:"timestamp"`
 	}{
-		Status:       status,
-		ConfigLoaded: configLoaded,
-		Timestamp:    time.Now().Format(time.RFC3339),
+		Status:    status,
+		Timestamp: time.Now().Format(time.RFC3339),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/kustomize-mutating-webhook/internal/webhook/server_test.go
+++ b/kustomize-mutating-webhook/internal/webhook/server_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xunholy/fluxcd-mutating-webhook/internal/config"
-	"github.com/xunholy/fluxcd-mutating-webhook/pkg/utils"
 	"github.com/xunholy/fluxcd-mutating-webhook/test"
 	"golang.org/x/time/rate"
 )
@@ -99,49 +98,32 @@ func TestHandleHealth(t *testing.T) {
 }
 
 func TestHandleReady(t *testing.T) {
-	t.Cleanup(func() {
-		utils.AppConfig.Mu.Lock()
-		utils.AppConfig.Config = nil
-		utils.AppConfig.Mu.Unlock()
-	})
-
-	utils.AppConfig.Mu.Lock()
-	utils.AppConfig.Config = map[string]string{"test": "value"}
-	utils.AppConfig.Mu.Unlock()
+	origCheck := ReadinessCheck
+	t.Cleanup(func() { ReadinessCheck = origCheck })
 
 	tests := []struct {
 		name           string
-		configLoaded   bool
+		ready          bool
 		expectedStatus int
-		expectedBody   map[string]interface{}
+		expectedStatus_ string
 	}{
 		{
-			name:           "Config loaded",
-			configLoaded:   true,
+			name:           "Informer synced",
+			ready:          true,
 			expectedStatus: http.StatusOK,
-			expectedBody: map[string]interface{}{
-				"status":       "Ready",
-				"configLoaded": true,
-			},
+			expectedStatus_: "Ready",
 		},
 		{
-			name:           "Config not loaded",
-			configLoaded:   false,
+			name:           "Informer not synced",
+			ready:          false,
 			expectedStatus: http.StatusServiceUnavailable,
-			expectedBody: map[string]interface{}{
-				"status":       "NotReady",
-				"configLoaded": false,
-			},
+			expectedStatus_: "NotReady",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if !tt.configLoaded {
-				utils.AppConfig.Mu.Lock()
-				utils.AppConfig.Config = map[string]string{}
-				utils.AppConfig.Mu.Unlock()
-			}
+			ReadinessCheck = func() bool { return tt.ready }
 
 			req, err := http.NewRequest("GET", "/ready", nil)
 			require.NoError(t, err)
@@ -160,8 +142,7 @@ func TestHandleReady(t *testing.T) {
 			err = json.Unmarshal(body, &result)
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.expectedBody["status"], result["status"])
-			assert.Equal(t, tt.expectedBody["configLoaded"], result["configLoaded"])
+			assert.Equal(t, tt.expectedStatus_, result["status"])
 			assert.Contains(t, result, "timestamp")
 			assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 		})

--- a/kustomize-mutating-webhook/pkg/utils/configwatcher.go
+++ b/kustomize-mutating-webhook/pkg/utils/configwatcher.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -32,6 +33,12 @@ type ConfigInformer struct {
 	updateCh             chan struct{}
 	done                 chan struct{}
 	stopOnce             sync.Once
+	ready                atomic.Bool
+}
+
+// Ready returns true once the informer caches have synced and the initial config load is complete.
+func (ci *ConfigInformer) Ready() bool {
+	return ci.ready.Load()
 }
 
 func NewConfigInformer(
@@ -265,6 +272,7 @@ func (ci *ConfigInformer) Start() error {
 
 	log.Info().Msg("Informer caches synced, performing initial config load")
 	ci.reloadConfig()
+	ci.ready.Store(true)
 
 	// Block until stopped
 	<-ci.done


### PR DESCRIPTION
## Summary

Decouples the readiness probe from the number of config keys loaded. The webhook is now marked ready once the informer cache has synced, regardless of whether any ConfigMaps/Secrets have data.

Fixes #12

## Problem

The `/ready` endpoint checked `len(AppConfig.Config) > 0`. If a user deployed the webhook without any ConfigMaps/Secrets (or with empty ones), the pod would stay NotReady forever, blocking Flux from reporting the HelmRelease as successful.

## Fix

- Added `Ready()` method on `ConfigInformer` backed by `atomic.Bool`, set to true after `WaitForCacheSync` + initial `reloadConfig` completes
- Added `ReadinessCheck` function variable on the server package, wired to `configInformer.Ready` in `main.go`
- `/ready` now returns 200 once the informer has synced, even with zero config keys
- If `ReadinessCheck` is nil (e.g., in tests), defaults to ready