### PR TITLE
Fix release-please illegal path traversal error

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,13 +7,6 @@
     "kustomize-mutating-webhook": {
       "package-name": "kustomize-mutating-webhook",
       "release-type": "go",
-      "extra-files": [
-        {
-          "type": "yaml",
-          "path": "../deploy/chart/kustomize-mutating-webhook/Chart.yaml",
-          "jsonpath": "$.appVersion"
-        }
-      ],
       "changelog-sections": [
         {
           "type": "feat",


### PR DESCRIPTION
## Summary

Removes the `extra-files` config from the Go app package that caused release-please to fail with:

```
illegal pathing characters in path: kustomize-mutating-webhook/../deploy/chart/kustomize-mutating-webhook/Chart.yaml
```

The `..` in the path is rejected by release-please as a security measure. The Helm release type already manages both `version` and `appVersion` in `Chart.yaml` natively, so the cross-package `extra-files` approach was unnecessary.