### PR TITLE
fix(ci): Use cr CLI directly to bypass broken change detection

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -60,10 +60,24 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Run chart-releaser
+      - name: Install chart-releaser
         uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
+        with:
+          install_only: true
+
+      - name: Upload chart and update index
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_SKIP_EXISTING: "true"
-        with:
-          charts_dir: deploy/chart
+          CR_OWNER: "${{ github.repository_owner }}"
+          CR_GIT_REPO: "${{ github.event.repository.name }}"
+          CHART_VERSION: "${{ steps.chart-version.outputs.version }}"
+        run: |
+          # Place packaged chart where cr expects it
+          mkdir -p .cr-release-packages
+          cp "kustomize-mutating-webhook-${CHART_VERSION}.tgz" .cr-release-packages/
+
+          # Upload chart package as a GitHub release asset (skip if release already exists)
+          cr upload --owner "$CR_OWNER" --git-repo "$CR_GIT_REPO" --skip-existing
+
+          # Regenerate and push the gh-pages index from all chart releases
+          cr index --owner "$CR_OWNER" --git-repo "$CR_GIT_REPO" --push


### PR DESCRIPTION
## Summary
- chart-releaser-action's change detection has been broken since 0.10.0 because Release Please tags (e.g. `kustomize-mutating-webhook-chart-v0.11.0`) point to the same commit as HEAD, causing `git diff` to find no changes
- This broke the `gh-pages` Helm repo index — versions 0.10.0, 0.10.1, and 0.11.0 were never published to the index, only to OCI
- Replaces the action's built-in flow with direct `cr upload` + `cr index` commands that skip change detection entirely, using `--skip-existing` for idempotency

## Impact
- Fixes Renovate not detecting new versions (it checks the gh-pages Helm index)
- After merge, a workflow_dispatch of "Publish Helm Chart" will backfill 0.10.0, 0.10.1, and 0.11.0 into the index

## Test plan
- [ ] Merge this PR
- [ ] Trigger `workflow_dispatch` on "Publish Helm Chart"
- [ ] Verify `https://xunholy.github.io/fluxcd-kustomize-mutating-webhook/index.yaml` includes 0.10.0, 0.10.1, 0.11.0