### PR TITLE
feat: bump Go from 1.26.1 to 1.26.4 to address CVEs

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -85,13 +85,13 @@ jobs:
           ref: ${{ github.event.release.tag_name || format('kustomize-mutating-webhook-{0}', steps.get-tag.outputs.tag) }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
         with:
           platforms: all
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           install: true
           version: latest

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -39,12 +39,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
         with:
           platforms: linux/amd64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           install: true
           version: latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.4 AS builder
 
 # Build arguments for cross-compilation
 ARG TARGETOS

--- a/kustomize-mutating-webhook/go.mod
+++ b/kustomize-mutating-webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/xunholy/fluxcd-mutating-webhook
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0


### PR DESCRIPTION
Go 1.26.4 includes security fixes to crypto/x509, html/template, cnet/url, and os packages introduced after 1.26.1.